### PR TITLE
Fix whisper warnings by using model directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,11 @@
 
 This project extracts audio from a video, transcribes Malayalam speech using the Whisper ASR model, and translates the transcript to English using `indictrans2`.
 
+Dependencies:
+
+- `transformers`
+- `soundfile`
+- `ffmpeg` (for audio extraction)
+- `torch` with CPU support
+
 Run `python main.py` after installing the dependencies.

--- a/main.py
+++ b/main.py
@@ -1,24 +1,31 @@
 from modules.audio_extractor import extract_audio_from_video
 from modules.translator import translate_malayalam_to_english
-from transformers import pipeline
+from transformers import (
+    WhisperForConditionalGeneration,
+    WhisperProcessor,
+)
+import soundfile as sf
+import torch
 
 # ─── CONFIG ───
 VIDEO_PATH = r"C:\\Users\\HP\\Desktop\\Meeting_2.mp4"
 AUDIO_PATH = "audio.wav"
 
-# ─── LOAD ASR PIPELINE ───
-asr_pipeline = pipeline(
-    "automatic-speech-recognition",
-    model="openai/whisper-tiny",
-    device=-1,
-    chunk_length_s=30,
-)
+# ─── LOAD ASR MODEL ───
+processor = WhisperProcessor.from_pretrained("openai/whisper-tiny")
+asr_model = WhisperForConditionalGeneration.from_pretrained("openai/whisper-tiny")
 
 
 def transcribe_malayalam(audio_path: str) -> str:
-    """Transcribe Malayalam speech to text using Whisper."""
-    result = asr_pipeline(audio_path)
-    return result["text"]
+    """Transcribe Malayalam speech to text using Whisper without warnings."""
+    speech, sr = sf.read(audio_path)
+    inputs = processor(speech, sampling_rate=sr, return_tensors="pt")
+    with torch.no_grad():
+        generated_ids = asr_model.generate(
+            input_features=inputs.input_features,
+            attention_mask=inputs.attention_mask,
+        )
+    return processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
 
 
 def main():


### PR DESCRIPTION
## Summary
- load `WhisperProcessor` and `WhisperForConditionalGeneration` directly
- replace pipeline-based transcription to avoid deprecation warnings
- document extra dependencies in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851f50a8434832cb51fd14d43f68b23