### PR TITLE
Fix attention_mask error in transcription

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,7 +23,6 @@ def transcribe_malayalam(audio_path: str) -> str:
     with torch.no_grad():
         generated_ids = asr_model.generate(
             input_features=inputs.input_features,
-            attention_mask=inputs.attention_mask,
         )
     return processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
 


### PR DESCRIPTION
## Summary
- fix Whisper transcription by removing nonexistent `attention_mask`

## Testing
- `python -m py_compile main.py modules/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68520033e3dc832cba3515b73d75af29