### PR TITLE
Fix IndicTrans2 tokenizer usage

### DIFF
--- a/modules/translator.py
+++ b/modules/translator.py
@@ -1,3 +1,5 @@
+"""Utility for translating Malayalam to English using IndicTrans2."""
+
 from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
 
 tokenizer = AutoTokenizer.from_pretrained(
@@ -9,6 +11,15 @@ model = AutoModelForSeq2SeqLM.from_pretrained(
 
 
 def translate_malayalam_to_english(text_ml: str) -> str:
-    inputs = tokenizer(text_ml, return_tensors="pt", truncation=True, max_length=512)
+    """Translate Malayalam text to English using IndicTrans2.
+
+    The tokenizer for IndicTrans2 expects the input string to contain the
+    source language code, target language code, and the text separated by
+    spaces. We prepend the codes ``mal_Mlym`` and ``eng_Latn`` before the
+    actual text to form a valid input.
+    """
+
+    text_with_lang = f"mal_Mlym eng_Latn {text_ml}"
+    inputs = tokenizer(text_with_lang, return_tensors="pt", truncation=True, max_length=512)
     output_ids = model.generate(**inputs, max_length=512)
     return tokenizer.decode(output_ids[0], skip_special_tokens=True)


### PR DESCRIPTION
## Summary
- add brief translator module description
- prepend language codes so IndicTrans2 tokenizer works

## Testing
- `python main.py` *(fails: requires >4GB model download)*

------
https://chatgpt.com/codex/tasks/task_e_68520523bc18832cb3058e0fc2d5e9ca