### PR TITLE
Expose translation wrapper in audio_processor

### DIFF
--- a/modules/audio_processor.py
+++ b/modules/audio_processor.py
@@ -2,6 +2,10 @@ import torch
 import torchaudio
 from transformers import Wav2Vec2Processor, Wav2Vec2ForCTC
 
+# Expose translation utility here for backward compatibility.
+# Some older code expects translate_malayalam_to_english in this module.
+from .translator import translate_malayalam_to_english
+
 SAMPLE_RATE = 16000
 
 # ASR model/processor


### PR DESCRIPTION
## Summary
- expose `translate_malayalam_to_english` from `audio_processor` for backwards compatibility

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6860604f26e0832cb8b59d96fc5637b8