### PR TITLE
Add transcript joining utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,6 @@ Dependencies:
 - `torch` with CPU support
 
 Run `python main.py` after installing the dependencies. Transcripts for each
-audio chunk will be saved as text files in the `transcripts` directory.
+audio chunk will be saved as text files in the `transcripts` directory. After
+all chunks are processed, the individual transcripts are automatically joined
+into `transcripts/full_transcript.txt`.

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import os
 from modules.audio_extractor import extract_audio_from_video
 from modules.audio_processor import transcribe_malayalam, split_audio
 from modules.translator import translate_malayalam_to_english
+from modules.transcript_joiner import join_transcripts
 
 # ─── CONFIG ───
 VIDEO_PATH = r"C:\\Users\\HP\\Desktop\\Meeting_2.mp4"
@@ -33,6 +34,11 @@ def main():
         transcript_path = os.path.join(TRANSCRIPT_DIR, f"chunk_{idx}.txt")
         with open(transcript_path, "w", encoding="utf-8") as f:
             f.write(ml_text)
+
+    # After processing all chunks, join the individual transcripts
+    final_transcript_path = os.path.join(TRANSCRIPT_DIR, "full_transcript.txt")
+    join_transcripts(TRANSCRIPT_DIR, final_transcript_path)
+    print(f"\n📄 Combined transcript saved to {final_transcript_path}")
 
 
 

--- a/modules/transcript_joiner.py
+++ b/modules/transcript_joiner.py
@@ -1,0 +1,25 @@
+"""Utility for joining multiple transcript files into a single file."""
+
+import glob
+import os
+from typing import List
+
+
+def join_transcripts(transcript_dir: str, output_file: str) -> str:
+    """Join ``*.txt`` files from ``transcript_dir`` and write to ``output_file``.
+
+    The files are joined in lexicographic order to match the order
+    of processed audio chunks. The combined transcript string is
+    returned.
+    """
+
+    pattern = os.path.join(transcript_dir, "*.txt")
+    file_paths: List[str] = sorted(glob.glob(pattern))
+    combined_lines: List[str] = []
+    for path in file_paths:
+        with open(path, "r", encoding="utf-8") as f:
+            combined_lines.append(f.read().strip())
+    combined_text = "\n".join(combined_lines)
+    with open(output_file, "w", encoding="utf-8") as out:
+        out.write(combined_text)
+    return combined_text


### PR DESCRIPTION
## Summary
- add a `transcript_joiner` module to concatenate transcript text files
- join transcripts automatically in `main.py`
- document the new combined transcript output in the README

## Testing
- `python -m py_compile main.py modules/*.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'ffmpeg')*

------
https://chatgpt.com/codex/tasks/task_e_687c22061c98832c8d82f72132630ea3