### PR TITLE
Add transcript polishing for business English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI-Agent
 
-This project extracts audio from a video, transcribes Malayalam speech using a Wav2Vec2 ASR model, and translates the transcript to English using `indictrans2`.
+This project extracts audio from a video, transcribes Malayalam speech using a Wav2Vec2 ASR model, and translates the transcript to English using `indictrans2`. The English text is then polished into formal business language by removing filler words and standardizing corporate terminology.
 
 Dependencies:
 
@@ -9,7 +9,4 @@ Dependencies:
 - `ffmpeg` (for audio extraction)
 - `torch` with CPU support
 
-Run `python main.py` after installing the dependencies. Transcripts for each
-audio chunk will be saved as text files in the `transcripts` directory. After
-all chunks are processed, the individual transcripts are automatically joined
-into `transcripts/full_transcript.txt`.
+Run `python main.py` after installing the dependencies. Malayalam transcripts for each audio chunk are saved as text files in the `transcripts` directory. Polished English translations are saved to `transcripts_en`. After all chunks are processed, the individual transcripts are automatically joined into `transcripts/full_transcript.txt` and `transcripts_en/full_transcript_polished.txt`.

--- a/main.py
+++ b/main.py
@@ -3,12 +3,14 @@ from modules.audio_extractor import extract_audio_from_video
 from modules.audio_processor import transcribe_malayalam, split_audio
 from modules.translator import translate_malayalam_to_english
 from modules.transcript_joiner import join_transcripts
+from modules.text_polisher import polish_business_english
 
 # ─── CONFIG ───
 VIDEO_PATH = r"C:\\Users\\HP\\Desktop\\Meeting_2.mp4"
 AUDIO_PATH = "audio.wav"
 CHUNK_DIR = "chunks"
 TRANSCRIPT_DIR = "transcripts"
+EN_TRANSCRIPT_DIR = "transcripts_en"
 
 
 
@@ -20,6 +22,7 @@ def main():
     print("🔪 Splitting audio into chunks...")
     chunk_paths = split_audio(AUDIO_PATH, CHUNK_DIR, chunk_duration=30)
     os.makedirs(TRANSCRIPT_DIR, exist_ok=True)
+    os.makedirs(EN_TRANSCRIPT_DIR, exist_ok=True)
 
     for idx, chunk in enumerate(chunk_paths, start=1):
         print(f"\n🧠 Transcribing Malayalam (chunk {idx})...")
@@ -28,17 +31,31 @@ def main():
 
         print("🌍 Translating to English...")
         en_text = translate_malayalam_to_english(ml_text)
-        print("📝 English translation:\n", en_text)
+        polished_text = polish_business_english(en_text)
+        print("📝 Polished English translation:\n", polished_text)
 
-        # Save transcript to a text file for each chunk
+        # Save transcripts to text files for each chunk
         transcript_path = os.path.join(TRANSCRIPT_DIR, f"chunk_{idx}.txt")
         with open(transcript_path, "w", encoding="utf-8") as f:
             f.write(ml_text)
 
+        en_transcript_path = os.path.join(EN_TRANSCRIPT_DIR, f"chunk_{idx}.txt")
+        with open(en_transcript_path, "w", encoding="utf-8") as f:
+            f.write(polished_text)
+
     # After processing all chunks, join the individual transcripts
     final_transcript_path = os.path.join(TRANSCRIPT_DIR, "full_transcript.txt")
     join_transcripts(TRANSCRIPT_DIR, final_transcript_path)
-    print(f"\n📄 Combined transcript saved to {final_transcript_path}")
+
+    final_en_transcript_path = os.path.join(
+        EN_TRANSCRIPT_DIR, "full_transcript_polished.txt"
+    )
+    join_transcripts(EN_TRANSCRIPT_DIR, final_en_transcript_path)
+
+    print(f"\n📄 Combined Malayalam transcript saved to {final_transcript_path}")
+    print(
+        f"📄 Combined polished English transcript saved to {final_en_transcript_path}"
+    )
 
 
 

--- a/modules/text_polisher.py
+++ b/modules/text_polisher.py
@@ -1,0 +1,48 @@
+"""Utilities for polishing transcripts into business English."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict
+
+FILLER_WORDS = {"um", "ah"}
+
+TERMINOLOGY_MAP: Dict[str, str] = {
+    r"\bsetting up\b": "deployment",
+    r"\bset up\b": "deploy",
+}
+
+
+def polish_business_english(text: str) -> str:
+    """Return a polished business English version of ``text``.
+
+    The function removes simple filler words, standardizes corporate
+    terminology, collapses whitespace, and applies basic sentence
+    capitalization and punctuation.
+    """
+
+    result = text
+
+    # Remove filler words
+    for filler in FILLER_WORDS:
+        result = re.sub(rf"\b{filler}\b", "", result, flags=re.IGNORECASE)
+
+    # Standardize terminology
+    for pattern, replacement in TERMINOLOGY_MAP.items():
+        result = re.sub(pattern, replacement, result, flags=re.IGNORECASE)
+
+    # Collapse whitespace
+    result = re.sub(r"\s+", " ", result).strip()
+
+    # Basic sentence handling
+    sentences = re.split(r"(?<=[.!?]) +", result)
+    polished_sentences = []
+    for sentence in sentences:
+        sentence = sentence.strip()
+        if not sentence:
+            continue
+        if sentence[-1] not in ".!?":
+            sentence += "."
+        polished_sentences.append(sentence[0].upper() + sentence[1:])
+
+    return " ".join(polished_sentences)


### PR DESCRIPTION
## Summary
- add `text_polisher` utility to remove filler words and standardize terminology
- polish English translations during processing and save combined polished transcript
- document polished transcript generation in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68929def615c832c8f05d67da6cb6bd9