### PR TITLE
Add meeting summarization module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI-Agent
 
-This project extracts audio from a video, transcribes Malayalam speech using a Wav2Vec2 ASR model, and translates the transcript to English using `indictrans2`. The English text is then polished into formal business language by removing filler words and standardizing corporate terminology.
+This project extracts audio from a video, transcribes Malayalam speech using a Wav2Vec2 ASR model, and translates the transcript to English using `indictrans2`. The English text is then polished into formal business language by removing filler words and standardizing corporate terminology. Finally, the polished transcript is summarised into a structured meeting report capturing issues, decisions and action items.
 
 Dependencies:
 
@@ -9,4 +9,4 @@ Dependencies:
 - `ffmpeg` (for audio extraction)
 - `torch` with CPU support
 
-Run `python main.py` after installing the dependencies. Malayalam transcripts for each audio chunk are saved as text files in the `transcripts` directory. Polished English translations are saved to `transcripts_en`. After all chunks are processed, the individual transcripts are automatically joined into `transcripts/full_transcript.txt` and `transcripts_en/full_transcript_polished.txt`.
+Run `python main.py` after installing the dependencies. Malayalam transcripts for each audio chunk are saved as text files in the `transcripts` directory. Polished English translations are saved to `transcripts_en`. After all chunks are processed, the individual transcripts are automatically joined into `transcripts/full_transcript.txt` and `transcripts_en/full_transcript_polished.txt`. A structured meeting summary is produced in `meeting_summary.txt`.

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from modules.audio_processor import transcribe_malayalam, split_audio
 from modules.translator import translate_malayalam_to_english
 from modules.transcript_joiner import join_transcripts
 from modules.text_polisher import polish_business_english
+from modules.meeting_summarizer import summarize_meeting
 
 # ─── CONFIG ───
 VIDEO_PATH = r"C:\\Users\\HP\\Desktop\\Meeting_2.mp4"
@@ -11,6 +12,20 @@ AUDIO_PATH = "audio.wav"
 CHUNK_DIR = "chunks"
 TRANSCRIPT_DIR = "transcripts"
 EN_TRANSCRIPT_DIR = "transcripts_en"
+
+# Metadata for the meeting summary
+MEETING_DATE = "2024-01-01"
+MEETING_PURPOSE = "Operations coordination meeting"
+ATTENDEES = [
+    "Installation",
+    "Production",
+    "Design",
+    "Estimation",
+    "Quality",
+    "Logistics",
+    "Stores",
+]
+SUMMARY_PATH = "meeting_summary.txt"
 
 
 
@@ -56,6 +71,22 @@ def main():
     print(
         f"📄 Combined polished English transcript saved to {final_en_transcript_path}"
     )
+
+    # Generate structured meeting summary from the polished transcript
+    with open(final_en_transcript_path, "r", encoding="utf-8") as f:
+        full_transcript_en = f.read()
+
+    summary = summarize_meeting(
+        full_transcript_en,
+        purpose=MEETING_PURPOSE,
+        date=MEETING_DATE,
+        attendees=ATTENDEES,
+    )
+
+    with open(SUMMARY_PATH, "w", encoding="utf-8") as f:
+        f.write(summary)
+
+    print(f"📄 Structured meeting summary saved to {SUMMARY_PATH}")
 
 
 

--- a/modules/meeting_summarizer.py
+++ b/modules/meeting_summarizer.py
@@ -1,0 +1,33 @@
+"""Utilities for generating structured meeting summaries."""
+
+from __future__ import annotations
+
+from typing import List
+
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+
+# Use a lightweight instruction-tuned model for summarization.
+tokenizer = AutoTokenizer.from_pretrained("google/flan-t5-base")
+model = AutoModelForSeq2SeqLM.from_pretrained("google/flan-t5-base")
+
+
+def summarize_meeting(transcript: str, purpose: str, date: str, attendees: List[str]) -> str:
+    """Return a structured meeting summary for ``transcript``.
+
+    The summary includes an introduction paragraph with ``purpose``, ``date``
+    and ``attendees`` followed by issue-wise bullet points highlighting
+    discussion points, decisions and action items.
+    """
+
+    intro = f"Meeting Purpose: {purpose}\nDate: {date}\nAttendees: {', '.join(attendees)}"
+    prompt = (
+        "You are an assistant that summarises meeting transcripts into structured reports.\n"
+        f"{intro}\n"
+        "Provide a structured summary. For each issue raised include:\n"
+        "- discussion highlights\n- decisions made\n- action items with owners and deadlines.\n"
+        "Use headings for each issue and bullet lists. Emphasise action items in **bold**.\n"
+        f"Transcript:\n{transcript}"
+    )
+    inputs = tokenizer(prompt, return_tensors="pt", truncation=True, max_length=2048)
+    outputs = model.generate(**inputs, max_length=1024)
+    return tokenizer.decode(outputs[0], skip_special_tokens=True)


### PR DESCRIPTION
## Summary
- Integrate a Flan-T5-based summarizer to generate issue-wise meeting summaries.
- Extend main pipeline to include meeting metadata and save structured summaries.
- Update documentation to describe new summarization output.

## Testing
- `python -m py_compile modules/meeting_summarizer.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6899dae3641c832c8c304105af514651